### PR TITLE
Fixed isFriendly, Swimming, FastAttack, Jump, SpiderWallClimbing, CreeperJump

### DIFF
--- a/src/main/java/milk/pureentities/entity/BaseEntity.java
+++ b/src/main/java/milk/pureentities/entity/BaseEntity.java
@@ -261,7 +261,11 @@ public abstract class BaseEntity extends EntityCreature{
     @Override
     public void attack(EntityDamageEvent source){
         if(this.isKnockback()){
-            return;
+        	if((source instanceof EntityDamageByEntityEvent)){
+        		if(!(((EntityDamageByEntityEvent) source).getDamager() instanceof Player)){
+        			return;
+        		}
+        	}
         }
 
         super.attack(source);
@@ -275,6 +279,7 @@ public abstract class BaseEntity extends EntityCreature{
 
         Entity damager = ((EntityDamageByEntityEvent) source).getDamager();
         Vector3 motion = new Vector3(this.x - damager.x, this.y - damager.y, this.z - damager.z).normalize();
+        
         this.motionX = motion.x * 0.19;
         this.motionZ = motion.z * 0.19;
         if(this instanceof FlyingEntity && !(this instanceof Blaze)){

--- a/src/main/java/milk/pureentities/entity/WalkingEntity.java
+++ b/src/main/java/milk/pureentities/entity/WalkingEntity.java
@@ -1,10 +1,13 @@
 package milk.pureentities.entity;
 
 import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockFence;
+import cn.nukkit.block.BlockFenceGate;
 import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.block.BlockSlab;
 import cn.nukkit.block.BlockStairs;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.level.Location;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.NukkitMath;
 import cn.nukkit.math.Vector2;
@@ -54,7 +57,6 @@ public abstract class WalkingEntity extends BaseEntity{
         if(this.baseTarget instanceof EntityCreature && ((EntityCreature) this.baseTarget).isAlive()){
             return;
         }
-
         int x, z;
         if(this.stayTime > 0){
             if(Utils.rand(1, 100) > 5){
@@ -94,11 +96,34 @@ public abstract class WalkingEntity extends BaseEntity{
         if(this.stayTime > 0){
             return false;
         }
-
-        Block block = this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x + dx), (int) this.y, NukkitMath.floorDouble(this.z + dz)));
-        if(block instanceof BlockSlab || block instanceof BlockStairs){
-            this.motionY = 0.5;
-            return true;
+        
+        Block block = this.getLevel().getBlock(new Vector3(NukkitMath.floorDouble(this.x + dx), (int) this.y, NukkitMath.floorDouble(this.z + dz)));
+        
+        int side = 0;
+        switch(this.getDirection()){
+        	case 2:
+        		side = Block.SIDE_NORTH;
+        		break;
+        	case 3:
+        		side = Block.SIDE_EAST;
+        		break;
+        	case 0:
+        		side = Block.SIDE_SOUTH;
+        		break;
+        	case 1:
+        		side = Block.SIDE_WEST;
+        		break;
+        }
+        
+        Block directionBlock = block.getSide(side);
+        Block directionUpBlock = block.getSide(Block.SIDE_UP);
+        if(!directionBlock.canPassThrough() && directionUpBlock.canPassThrough()){
+        	if(directionBlock instanceof BlockFence || directionBlock instanceof BlockFenceGate){
+        		this.motionY = this.getGravity() * 2;
+        	}else{
+        		this.motionY = this.getGravity() * 4;
+        	}
+        	return true;
         }
         return false;
     }

--- a/src/main/java/milk/pureentities/entity/WalkingEntity.java
+++ b/src/main/java/milk/pureentities/entity/WalkingEntity.java
@@ -78,10 +78,6 @@ public abstract class WalkingEntity extends BaseEntity{
     }
 
     protected boolean checkJump(double dx, double dz){
-        if(!this.onGround){
-            return false;
-        }
-
         if(this.motionY == this.getGravity() * 2){
             return this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) this.y, NukkitMath.floorDouble(this.z))) instanceof BlockLiquid;
         }else{
@@ -89,6 +85,10 @@ public abstract class WalkingEntity extends BaseEntity{
                 this.motionY = this.getGravity() * 2;
                 return true;
             }
+        }
+
+        if(!this.onGround){
+            return false;
         }
 
         if(this.stayTime > 0){
@@ -109,8 +109,7 @@ public abstract class WalkingEntity extends BaseEntity{
         }
         
         if(this.isKnockback()){
-            this.move(this.motionX * tickDiff, this.motionY * tickDiff, this.motionZ * tickDiff);
-            this.motionY -= 0.25 * tickDiff;
+            this.move(this.motionX * tickDiff, this.motionY * tickDiff * 0.05, this.motionZ * tickDiff);
             this.updateMovement();
             return null;
         }
@@ -154,7 +153,8 @@ public abstract class WalkingEntity extends BaseEntity{
             if(this.onGround){
                 this.motionY = 0;
             }else if(this.motionY > -this.getGravity() * 4){
-                this.motionY = -this.getGravity() * 4;
+                if(!(this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) (this.y + 0.8), NukkitMath.floorDouble(this.z))) instanceof BlockLiquid))
+                	this.motionY -= this.getGravity() * 1;
             }else{
                 this.motionY -= this.getGravity() * tickDiff;
             }

--- a/src/main/java/milk/pureentities/entity/monster/walking/Creeper.java
+++ b/src/main/java/milk/pureentities/entity/monster/walking/Creeper.java
@@ -1,5 +1,6 @@
 package milk.pureentities.entity.monster.walking;
 
+import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.EntityCreature;
 import cn.nukkit.entity.EntityExplosive;
@@ -7,6 +8,7 @@ import cn.nukkit.entity.data.ByteEntityData;
 import cn.nukkit.event.entity.ExplosionPrimeEvent;
 import cn.nukkit.level.Explosion;
 import cn.nukkit.level.format.FullChunk;
+import cn.nukkit.math.NukkitMath;
 import cn.nukkit.math.Vector2;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -176,7 +178,8 @@ public class Creeper extends WalkingMonster implements EntityExplosive{
             if(this.onGround){
                 this.motionY = 0;
             }else if(this.motionY > -this.getGravity() * 4){
-                this.motionY = -this.getGravity() * 4;
+                if(!(this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) (this.y + 0.8), NukkitMath.floorDouble(this.z))) instanceof BlockLiquid))
+                	this.motionY -= this.getGravity() * 1;
             }else{
                 this.motionY -= this.getGravity() * tickDiff;
             }

--- a/src/main/java/milk/pureentities/entity/monster/walking/IronGolem.java
+++ b/src/main/java/milk/pureentities/entity/monster/walking/IronGolem.java
@@ -6,7 +6,6 @@ import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.format.FullChunk;
-import cn.nukkit.math.Vector3;
 import cn.nukkit.Player;
 import cn.nukkit.nbt.tag.CompoundTag;
 import milk.pureentities.entity.monster.WalkingMonster;
@@ -19,6 +18,7 @@ public class IronGolem extends WalkingMonster{
 
     public IronGolem(FullChunk chunk, CompoundTag nbt){
         super(chunk, nbt);
+        this.setFriendly(true);
     }
 
     @Override
@@ -46,7 +46,6 @@ public class IronGolem extends WalkingMonster{
         this.setMaxHealth(100);
         super.initEntity();
 
-        this.setFriendly(true);
         this.setDamage(new int[]{0, 21, 21, 21});
         this.setMinDamage(new int[]{0, 7, 7, 7});
     }
@@ -97,7 +96,7 @@ public class IronGolem extends WalkingMonster{
     }
 
     public boolean targetOption(EntityCreature creature, double distance){
-        return !(creature instanceof Player) && creature.isAlive() && distance <= 60;
+    	return !(creature instanceof Player) && creature.isAlive() && distance <= 60;
     }
 
     public Item[] getDrops(){

--- a/src/main/java/milk/pureentities/entity/monster/walking/SnowGolem.java
+++ b/src/main/java/milk/pureentities/entity/monster/walking/SnowGolem.java
@@ -23,6 +23,7 @@ public class SnowGolem extends WalkingMonster{
 
     public SnowGolem(FullChunk chunk, CompoundTag nbt){
         super(chunk, nbt);
+        this.setFriendly(true);
     }
 
     @Override
@@ -43,8 +44,6 @@ public class SnowGolem extends WalkingMonster{
     @Override
     public void initEntity(){
         super.initEntity();
-
-        this.setFriendly(true);
     }
 
     @Override

--- a/src/main/java/milk/pureentities/entity/monster/walking/Spider.java
+++ b/src/main/java/milk/pureentities/entity/monster/walking/Spider.java
@@ -2,6 +2,9 @@ package milk.pureentities.entity.monster.walking;
 
 import cn.nukkit.Player;
 import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockFence;
+import cn.nukkit.block.BlockFenceGate;
+import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.EntityCreature;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
@@ -44,7 +47,7 @@ public class Spider extends WalkingMonster{
     public float getEyeHeight(){
         return 1;
     }
-
+    
     @Override
     public double getSpeed(){
         return 1.13;
@@ -151,13 +154,51 @@ public class Spider extends WalkingMonster{
             if(this.onGround){
                 this.motionY = 0;
             }else if(this.motionY > -this.getGravity() * 4){
-                this.motionY = -this.getGravity() * 4;
+                if(!(this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) (this.y + 0.8), NukkitMath.floorDouble(this.z))) instanceof BlockLiquid))
+                	this.motionY -= this.getGravity() * 1;
             }else{
                 this.motionY -= this.getGravity() * tickDiff;
             }
         }
         this.updateMovement();
         return true;
+    }
+
+    @Override
+    protected boolean checkJump(double dx, double dz){
+        if(this.motionY == this.getGravity() * 2){
+            return this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) this.y, NukkitMath.floorDouble(this.z))) instanceof BlockLiquid;
+        }else{
+            if(this.level.getBlock(new Vector3(NukkitMath.floorDouble(this.x), (int) (this.y + 0.8), NukkitMath.floorDouble(this.z))) instanceof BlockLiquid){
+                this.motionY = this.getGravity() * 2;
+                return true;
+            }
+        }
+
+        Block block = this.getLevel().getBlock(new Vector3(NukkitMath.floorDouble(this.x + dx), (int) this.y, NukkitMath.floorDouble(this.z + dz)));
+        
+        int side = 0;
+        switch(this.getDirection()){
+        	case 2:
+        		side = Block.SIDE_NORTH;
+        		break;
+        	case 3:
+        		side = Block.SIDE_EAST;
+        		break;
+        	case 0:
+        		side = Block.SIDE_SOUTH;
+        		break;
+        	case 1:
+        		side = Block.SIDE_WEST;
+        		break;
+        }
+        
+        Block directionBlock = block.getSide(side);
+        if(!directionBlock.canPassThrough()){
+        	this.motionY = this.getGravity() * 3;
+        	return true;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
아래 3개 현상 짧게 고쳐봤습니다, (이제 수영 잘합니다)

유저가 몬스터를 연속으로 빠르게 공격 하는게 불가능하고 1초 정도의 텀이 생기는 현상
+ BaseEntity의 attack 함수가 호출될때 해당 몬스터가 넉벡중이면 데미지를 주지 않는데,
몬스터 간에 공격시 연속공격만 막으면 된다고 보고 유저 공격은 예외처리함.

아군 몬스터가 적군 몬스터를 공격 안 하는 현상
+ setFriendly(true) 호출이 initEntity 에 있어서 동시성 문제가 생겨서
실제 클래스엔 반영이 안되던 문제가 있어서 생성자 메소드로 위치 옮김.

몬스터들이 수영 못하는 현상
+ WalkingEntity의 updateMove의 Y축넉벡 보정코드를 제거 후,
move 시의 Y축 변동량을 줄임, 또한 점프 관련해서도 중력을 한번에
최대치로 받는 것을 기본중력 이외에 처음 0의 속도에서 기본중력속도까지
가속도가 붙어서 이어지게끔 변경함, checkJump 메소드의 수영 시스템을
땅에 닿지 않아도 작동하게 땅에 닿았는지 체크보다 수영이 먼저 되게 순서변경 및 물에선 중력 없게함